### PR TITLE
Add rate limiting and retry logic to subscriptions

### DIFF
--- a/__tests__/subscriptions.test.ts
+++ b/__tests__/subscriptions.test.ts
@@ -549,7 +549,7 @@ describe("subscriptions", () => {
       expect(result).toEqual({ sub_old: "sub_new" });
     });
 
-    it("should throw error when no payment method found on customer", async () => {
+    it("should skip subscription when no payment method found on customer", async () => {
       const customer = createMockCustomer({ id: "cus_test" });
       const subscription = createMockSubscription({
         id: "sub_test",
@@ -566,9 +566,19 @@ describe("subscriptions", () => {
         createMockListResponse([])
       );
 
-      await expect(
-        migrateSubscriptions(oldStripe, newStripe, [], [], false)
-      ).rejects.toThrow("Failed to find payment method on customer");
+      const result = await migrateSubscriptions(
+        oldStripe,
+        newStripe,
+        [],
+        [],
+        false
+      );
+
+      expect(result).toEqual({});
+      expect(newStripe.subscriptions.create).not.toHaveBeenCalled();
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("no payment method found for customer cus_test")
+      );
     });
 
     describe("dry-run mode", () => {

--- a/src/lib/subscriptions.ts
+++ b/src/lib/subscriptions.ts
@@ -2,40 +2,20 @@ import crypto from "node:crypto";
 import chalk from "chalk";
 import type Stripe from "stripe";
 
-// Rate limiting configuration
-const DELAY_BETWEEN_SUBSCRIPTIONS_MS = 200; // 200ms between each subscription = ~5/sec
-const MAX_RETRIES = 5;
-const INITIAL_RETRY_DELAY_MS = 1000;
+// Throttle between consecutive Stripe requests (~5 requests/sec by default).
+// Transient rate-limit errors are retried by the Stripe SDK itself via
+// maxNetworkRetries (see utils.ts); this delay just keeps sustained
+// throughput well under Stripe's rate limits.
+const delayBetweenRequestsMs = Number(
+  process.env.STRIPE_MIGRATE_DELAY_MS ?? 200
+);
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const withRetry = async <T>(
-  fn: () => Promise<T>,
-  context: string,
-  retries = MAX_RETRIES,
-  delay = INITIAL_RETRY_DELAY_MS
-): Promise<T> => {
-  try {
-    return await fn();
-  } catch (error) {
-    const isRateLimitError =
-      error instanceof Error &&
-      (error.message.includes("rate limit") ||
-        error.message.includes("Rate limit") ||
-        (error as any).code === "rate_limit");
-
-    if (isRateLimitError && retries > 0) {
-      console.log(
-        chalk.yellow(
-          `Rate limit hit for ${context}, waiting ${delay}ms before retry (${retries} retries left)...`
-        )
-      );
-      await sleep(delay);
-      return withRetry(fn, context, retries - 1, delay * 2);
-    }
-    throw error;
-  }
-};
+const sleep = (ms: number): Promise<void> =>
+  ms > 0
+    ? new Promise((resolve) => {
+        setTimeout(resolve, ms);
+      })
+    : Promise.resolve();
 
 export const getAnonymisedEmail = (email: string) => {
   const emailHash = crypto.createHash("md5").update(email).digest("hex");
@@ -59,10 +39,7 @@ export const fetchSubscriptions = async (stripe: Stripe) => {
       listParams.starting_after = startingAfter;
     }
 
-    const response = await withRetry(
-      () => stripe.subscriptions.list(listParams),
-      "fetchSubscriptions"
-    );
+    const response = await stripe.subscriptions.list(listParams);
 
     subscriptions.push(...response.data);
 
@@ -97,10 +74,7 @@ export const fetchCustomers = async (stripe: Stripe) => {
       listParams.starting_after = startingAfter;
     }
 
-    const response = await withRetry(
-      () => stripe.customers.list(listParams),
-      "fetchCustomers"
-    );
+    const response = await stripe.customers.list(listParams);
 
     customers.push(...response.data);
 
@@ -156,13 +130,9 @@ export const cancelAllSubscriptions = async (stripe: Stripe) => {
   let succeeded = 0;
   let failed = 0;
 
-  // Process sequentially with rate limiting
   for (const subscription of subscriptions) {
     try {
-      await withRetry(
-        () => stripe.subscriptions.cancel(subscription.id),
-        `cancel ${subscription.id}`
-      );
+      await stripe.subscriptions.cancel(subscription.id);
       console.log(chalk.blue(`Cancelled subscription ${subscription.id}`));
       succeeded++;
     } catch (error) {
@@ -171,7 +141,8 @@ export const cancelAllSubscriptions = async (stripe: Stripe) => {
       );
       failed++;
     }
-    await sleep(DELAY_BETWEEN_SUBSCRIPTIONS_MS);
+
+    await sleep(delayBetweenRequestsMs);
   }
 
   console.log(chalk.green(`\nDone. Cancelled ${succeeded} subscriptions.`));
@@ -180,6 +151,344 @@ export const cancelAllSubscriptions = async (stripe: Stripe) => {
     console.log(chalk.red(`Failed to cancel ${failed} subscriptions.`));
   }
 };
+
+interface MigrationContext {
+  oldStripe: Stripe;
+  newStripe: Stripe;
+  customerIds: string[];
+  dryRun: boolean;
+  mockCustomers: Stripe.Customer[];
+  oldCustomersToMigrate: Stripe.Customer[];
+}
+
+type MigrateSubscriptionResult =
+  | { status: "created"; newSubscription: Stripe.Subscription }
+  | { status: "skipped"; reason: string };
+
+const createMockCustomers = async (
+  newStripe: Stripe,
+  customers: Stripe.Customer[]
+) => {
+  const mockCustomers: Stripe.Customer[] = [];
+
+  for (const customer of customers) {
+    const newCustomer = await newStripe.customers.create({
+      email: customer.email ? getAnonymisedEmail(customer.email) : undefined,
+      name: customer.name ?? undefined,
+      payment_method: "pm_card_visa",
+    });
+
+    console.log(
+      chalk.blue(
+        `[Dry run] mocked customer ${newCustomer.email} (${newCustomer.id})...`
+      )
+    );
+
+    mockCustomers.push(newCustomer);
+    await sleep(delayBetweenRequestsMs);
+  }
+
+  return mockCustomers;
+};
+
+// biome-ignore-start lint/complexity/noExcessiveCognitiveComplexity: Migration logic requires handling many subscription properties
+const migrateSubscription = async (
+  subscription: Stripe.Subscription,
+  {
+    oldStripe,
+    newStripe,
+    customerIds,
+    dryRun,
+    mockCustomers,
+    oldCustomersToMigrate,
+  }: MigrationContext
+): Promise<MigrateSubscriptionResult> => {
+  let customerId: Stripe.SubscriptionCreateParams["customer"] =
+    typeof subscription.customer === "string"
+      ? subscription.customer
+      : subscription.customer?.id;
+
+  let default_payment_method: Stripe.SubscriptionCreateParams["default_payment_method"];
+
+  let automatic_tax: Stripe.SubscriptionCreateParams["automatic_tax"] =
+    subscription.automatic_tax
+      ? {
+          enabled: subscription.automatic_tax.enabled,
+          liability: subscription.automatic_tax.liability,
+        }
+      : undefined;
+
+  if (dryRun) {
+    const oldCustomer =
+      typeof subscription.customer === "string"
+        ? await oldStripe.customers.retrieve(subscription.customer)
+        : subscription.customer;
+
+    if (!oldCustomer || oldCustomer.deleted) {
+      return { status: "skipped", reason: "customer deleted" };
+    }
+
+    const mockCustomer = mockCustomers.find((mock, index) =>
+      oldCustomer.email
+        ? mock.email === getAnonymisedEmail(oldCustomer.email)
+        : index ===
+          mockCustomers.findIndex((_, i) => !oldCustomersToMigrate[i]?.email)
+    );
+
+    if (!mockCustomer) {
+      return { status: "skipped", reason: "no mock customer found" };
+    }
+
+    console.log(
+      chalk.blue(
+        `[Dry run] found mock customer ${mockCustomer.email} (${mockCustomer.id})...`
+      )
+    );
+
+    const paymentMethod = await newStripe.paymentMethods.list({
+      customer: mockCustomer.id,
+    });
+
+    if (!paymentMethod.data[0]) {
+      throw new Error("Failed to find payment method on mock customer");
+    }
+
+    customerId = mockCustomer.id;
+    default_payment_method = paymentMethod.data[0].id;
+    automatic_tax = undefined;
+  } else {
+    if (customerIds.length && !customerIds.includes(customerId)) {
+      return {
+        status: "skipped",
+        reason: "customer not in provided customer ids",
+      };
+    }
+
+    const customerPaymentMethod = await newStripe.paymentMethods.list({
+      customer: customerId,
+    });
+
+    if (!customerPaymentMethod.data[0]) {
+      return {
+        status: "skipped",
+        reason: `no payment method found for customer ${customerId}`,
+      };
+    }
+
+    default_payment_method = customerPaymentMethod.data[0].id;
+  }
+
+  const billing_thresholds: Stripe.SubscriptionCreateParams["billing_thresholds"] =
+    subscription.billing_thresholds
+      ? {
+          amount_gte: subscription.billing_thresholds.amount_gte ?? undefined,
+          reset_billing_cycle_anchor:
+            subscription.billing_thresholds.reset_billing_cycle_anchor ??
+            undefined,
+        }
+      : undefined;
+
+  const default_source: Stripe.SubscriptionCreateParams["default_source"] =
+    typeof subscription.default_source === "string"
+      ? subscription.default_source
+      : subscription.default_source?.id;
+
+  const application_fee_percent: Stripe.SubscriptionCreateParams["application_fee_percent"] =
+    subscription.application_fee_percent ?? undefined;
+
+  const default_tax_rates: Stripe.SubscriptionCreateParams["default_tax_rates"] =
+    subscription.default_tax_rates
+      ? subscription.default_tax_rates.map((rate) => rate.id)
+      : undefined;
+
+  const items: Stripe.SubscriptionCreateParams["items"] = subscription.items
+    ? subscription.items.data.map((item) => ({
+        billing_thresholds: item.billing_thresholds?.usage_gte
+          ? {
+              usage_gte: item.billing_thresholds.usage_gte ?? undefined,
+            }
+          : undefined,
+        metadata: item.metadata,
+        // plan: item.plan.id,
+        price: item.price?.id,
+        price_data: undefined,
+        quantity: item.quantity,
+        tax_rates: item.tax_rates
+          ? item.tax_rates.map((rate) => rate.id)
+          : undefined,
+      }))
+    : undefined;
+
+  const on_behalf_of: Stripe.SubscriptionCreateParams["on_behalf_of"] =
+    typeof subscription.on_behalf_of === "string"
+      ? subscription.on_behalf_of
+      : subscription.on_behalf_of?.id;
+
+  const payment_settings: Stripe.SubscriptionCreateParams["payment_settings"] =
+    subscription.payment_settings
+      ? {
+          payment_method_options: subscription.payment_settings
+            .payment_method_options
+            ? {
+                acss_debit: subscription.payment_settings.payment_method_options
+                  .acss_debit
+                  ? {
+                      mandate_options: subscription.payment_settings
+                        .payment_method_options.acss_debit.mandate_options
+                        ? {
+                            transaction_type:
+                              subscription.payment_settings
+                                .payment_method_options.acss_debit
+                                .mandate_options.transaction_type ?? undefined,
+                          }
+                        : undefined,
+                      verification_method:
+                        subscription.payment_settings.payment_method_options
+                          .acss_debit.verification_method ?? undefined,
+                    }
+                  : undefined,
+                bancontact:
+                  subscription.payment_settings.payment_method_options
+                    .bancontact ?? undefined,
+                card: subscription.payment_settings.payment_method_options.card
+                  ? {
+                      mandate_options: subscription.payment_settings
+                        .payment_method_options.card.mandate_options
+                        ? {
+                            amount:
+                              subscription.payment_settings
+                                .payment_method_options.card.mandate_options
+                                .amount ?? undefined,
+                            amount_type:
+                              subscription.payment_settings
+                                .payment_method_options.card.mandate_options
+                                .amount_type ?? undefined,
+                            description:
+                              subscription.payment_settings
+                                .payment_method_options.card.mandate_options
+                                .description ?? undefined,
+                          }
+                        : undefined,
+                      network:
+                        subscription.payment_settings.payment_method_options
+                          .card.network ?? undefined,
+                      request_three_d_secure:
+                        subscription.payment_settings.payment_method_options
+                          .card.request_three_d_secure ?? undefined,
+                    }
+                  : undefined,
+                customer_balance: subscription.payment_settings
+                  .payment_method_options.customer_balance
+                  ? {
+                      bank_transfer: subscription.payment_settings
+                        .payment_method_options.customer_balance.bank_transfer
+                        ? {
+                            eu_bank_transfer:
+                              subscription.payment_settings
+                                .payment_method_options.customer_balance
+                                .bank_transfer.eu_bank_transfer ?? undefined,
+                            type:
+                              subscription.payment_settings
+                                .payment_method_options.customer_balance
+                                .bank_transfer.type ?? undefined,
+                          }
+                        : undefined,
+                      funding_type:
+                        subscription.payment_settings.payment_method_options
+                          .customer_balance.funding_type ?? undefined,
+                    }
+                  : undefined,
+                konbini:
+                  subscription.payment_settings.payment_method_options
+                    .konbini ?? undefined,
+                us_bank_account:
+                  subscription.payment_settings.payment_method_options
+                    .us_bank_account ?? undefined,
+              }
+            : undefined,
+          payment_method_types:
+            subscription.payment_settings.payment_method_types,
+          save_default_payment_method:
+            subscription.payment_settings.save_default_payment_method ??
+            undefined,
+        }
+      : undefined;
+
+  const transfer_data: Stripe.SubscriptionCreateParams["transfer_data"] =
+    subscription.transfer_data
+      ? {
+          destination:
+            typeof subscription.transfer_data.destination === "string"
+              ? subscription.transfer_data.destination
+              : subscription.transfer_data.destination?.id,
+          amount_percent:
+            subscription.transfer_data.amount_percent ?? undefined,
+        }
+      : undefined;
+
+  // Setting the trial_end to the current period end is important
+  // for maintaining the same billing period:
+  // https://support.stripe.com/questions/recreate-subscriptions-and-plans-after-moving-customer-data-to-a-new-stripe-account
+  const trial_end: Stripe.SubscriptionCreateParams["trial_end"] =
+    subscription.current_period_end;
+
+  let promotion_code: Stripe.SubscriptionCreateParams["promotion_code"] =
+    typeof subscription.discount?.promotion_code === "string"
+      ? subscription.discount?.promotion_code
+      : subscription.discount?.promotion_code?.id;
+
+  if (subscription.discount?.coupon) {
+    promotion_code = undefined;
+  }
+
+  const pending_invoice_item_interval: Stripe.SubscriptionCreateParams["pending_invoice_item_interval"] =
+    subscription.pending_invoice_item_interval;
+
+  let cancel_at: Stripe.SubscriptionCreateParams["cancel_at"] =
+    subscription.cancel_at ?? undefined;
+
+  if (subscription.cancel_at_period_end) {
+    cancel_at = undefined;
+  }
+
+  const newSubscription = await newStripe.subscriptions.create({
+    add_invoice_items: undefined,
+    application_fee_percent,
+    automatic_tax,
+    backdate_start_date: undefined,
+    billing_cycle_anchor: undefined,
+    billing_thresholds,
+    cancel_at_period_end: subscription.cancel_at_period_end,
+    cancel_at,
+    collection_method: subscription.collection_method,
+    coupon: subscription.discount?.coupon?.id ?? undefined,
+    currency: subscription.currency,
+    customer: customerId,
+    days_until_due: subscription.days_until_due ?? undefined,
+    default_payment_method,
+    default_source,
+    default_tax_rates,
+    description: subscription.description ?? undefined,
+    expand: undefined,
+    items,
+    metadata: subscription.metadata,
+    off_session: undefined,
+    on_behalf_of,
+    payment_behavior: undefined,
+    payment_settings,
+    pending_invoice_item_interval,
+    promotion_code,
+    proration_behavior: undefined,
+    transfer_data,
+    trial_end,
+    trial_from_plan: undefined,
+    trial_period_days: undefined,
+    trial_settings: subscription.trial_settings ?? undefined,
+  });
+
+  return { status: "created", newSubscription };
+};
+// biome-ignore-end lint/complexity/noExcessiveCognitiveComplexity: Migration logic requires handling many subscription properties
 
 export const migrateSubscriptions = async (
   oldStripe: Stripe,
@@ -229,29 +538,9 @@ export const migrateSubscriptions = async (
       oldCustomersToMigrate = oldCustomersToMigrate.slice(0, 20);
     }
 
-    // Process sequentially with rate limiting
-    for (const customer of oldCustomersToMigrate) {
-      const newCustomer = await withRetry(
-        () =>
-          newStripe.customers.create({
-            email: customer.email
-              ? getAnonymisedEmail(customer.email)
-              : undefined,
-            name: customer.name ?? undefined,
-            payment_method: "pm_card_visa",
-          }),
-        `create mock customer ${customer.id}`
-      );
-
-      console.log(
-        chalk.blue(
-          `[Dry run] mocked customer ${newCustomer.email} (${newCustomer.id})...`
-        )
-      );
-
-      mockCustomers.push(newCustomer);
-      await sleep(DELAY_BETWEEN_SUBSCRIPTIONS_MS);
-    }
+    mockCustomers.push(
+      ...(await createMockCustomers(newStripe, oldCustomersToMigrate))
+    );
   } else {
     console.log(
       chalk.blue(`Migrating ${oldCustomersToMigrate.length} customers...`)
@@ -283,330 +572,43 @@ export const migrateSubscriptions = async (
 
   console.log(
     chalk.blue(
-      `\nProcessing ${subscriptionsToMigrate.length} active subscriptions sequentially...`
+      `\nProcessing ${subscriptionsToMigrate.length} active subscriptions...`
     )
   );
 
-  let processed = 0;
+  let skipped = 0;
   let failed = 0;
 
-  // Process subscriptions sequentially with rate limiting
-  for (const subscription of subscriptionsToMigrate) {
-    processed++;
-    const progress = `[${processed}/${subscriptionsToMigrate.length}]`;
+  const context: MigrationContext = {
+    oldStripe,
+    newStripe,
+    customerIds,
+    dryRun,
+    mockCustomers,
+    oldCustomersToMigrate,
+  };
+
+  for (const [index, subscription] of subscriptionsToMigrate.entries()) {
+    const progress = `[${index + 1}/${subscriptionsToMigrate.length}]`;
 
     try {
-      let customerId: Stripe.SubscriptionCreateParams["customer"] =
-        typeof subscription.customer === "string"
-          ? subscription.customer
-          : subscription.customer?.id;
+      const result = await migrateSubscription(subscription, context);
 
-      let default_payment_method: Stripe.SubscriptionCreateParams["default_payment_method"];
-
-      let automatic_tax: Stripe.SubscriptionCreateParams["automatic_tax"] =
-        subscription.automatic_tax
-          ? {
-              enabled: subscription.automatic_tax.enabled,
-              liability: subscription.automatic_tax.liability,
-            }
-          : undefined;
-
-      if (dryRun) {
-        const oldCustomer =
-          typeof subscription.customer === "string"
-            ? await withRetry(
-                () => oldStripe.customers.retrieve(subscription.customer as string),
-                `retrieve customer ${subscription.customer}`
-              )
-            : subscription.customer;
-
-        if (!oldCustomer || oldCustomer.deleted) {
-          console.log(
-            chalk.yellow(`${progress} Skipping - customer deleted`)
-          );
-          continue;
-        }
-
-        const mockCustomer = mockCustomers.find((mock, index) =>
-          oldCustomer.email
-            ? mock.email === getAnonymisedEmail(oldCustomer.email)
-            : index ===
-              mockCustomers.findIndex(
-                (_, i) => !oldCustomersToMigrate[i]?.email
-              )
-        );
-
-        if (!mockCustomer) {
-          console.log(
-            chalk.yellow(`${progress} Skipping - no mock customer found`)
-          );
-          continue;
-        }
-
+      if (result.status === "created") {
+        subscriptionMapping[subscription.id] = result.newSubscription.id;
         console.log(
-          chalk.blue(
-            `${progress} [Dry run] found mock customer ${mockCustomer.email} (${mockCustomer.id})...`
+          chalk.green(
+            `${progress} Created subscription ${result.newSubscription.id} for ${result.newSubscription.customer}`
           )
         );
-
-        const paymentMethod = await withRetry(
-          () => newStripe.paymentMethods.list({ customer: mockCustomer.id }),
-          `list payment methods for ${mockCustomer.id}`
-        );
-
-        if (!paymentMethod.data[0]) {
-          throw new Error("Failed to find payment method on mock customer");
-        }
-
-        customerId = mockCustomer.id;
-        default_payment_method = paymentMethod.data[0].id;
-        automatic_tax = undefined;
       } else {
-        if (customerIds.length && !customerIds.includes(customerId)) {
-          continue;
-        }
-
-        const customerPaymentMethod = await withRetry(
-          () => newStripe.paymentMethods.list({ customer: customerId }),
-          `list payment methods for ${customerId}`
+        skipped++;
+        console.log(
+          chalk.yellow(
+            `${progress} Skipped subscription ${subscription.id}: ${result.reason}`
+          )
         );
-
-        if (!customerPaymentMethod.data[0]) {
-          console.log(
-            chalk.yellow(
-              `${progress} Skipping ${subscription.id} - no payment method found for customer ${customerId}`
-            )
-          );
-          continue;
-        }
-
-        default_payment_method = customerPaymentMethod.data[0].id;
       }
-
-      const billing_thresholds: Stripe.SubscriptionCreateParams["billing_thresholds"] =
-        subscription.billing_thresholds
-          ? {
-              amount_gte:
-                subscription.billing_thresholds.amount_gte ?? undefined,
-              reset_billing_cycle_anchor:
-                subscription.billing_thresholds.reset_billing_cycle_anchor ??
-                undefined,
-            }
-          : undefined;
-
-      const default_source: Stripe.SubscriptionCreateParams["default_source"] =
-        typeof subscription.default_source === "string"
-          ? subscription.default_source
-          : subscription.default_source?.id;
-
-      const application_fee_percent: Stripe.SubscriptionCreateParams["application_fee_percent"] =
-        subscription.application_fee_percent ?? undefined;
-
-      const default_tax_rates: Stripe.SubscriptionCreateParams["default_tax_rates"] =
-        subscription.default_tax_rates
-          ? subscription.default_tax_rates.map((rate) => rate.id)
-          : undefined;
-
-      const items: Stripe.SubscriptionCreateParams["items"] = subscription.items
-        ? subscription.items.data.map((item) => ({
-            billing_thresholds: item.billing_thresholds?.usage_gte
-              ? {
-                  usage_gte: item.billing_thresholds.usage_gte ?? undefined,
-                }
-              : undefined,
-            metadata: item.metadata,
-            // plan: item.plan.id,
-            price: item.price?.id,
-            price_data: undefined,
-            quantity: item.quantity,
-            tax_rates: item.tax_rates
-              ? item.tax_rates.map((rate) => rate.id)
-              : undefined,
-          }))
-        : undefined;
-
-      const on_behalf_of: Stripe.SubscriptionCreateParams["on_behalf_of"] =
-        typeof subscription.on_behalf_of === "string"
-          ? subscription.on_behalf_of
-          : subscription.on_behalf_of?.id;
-
-      const payment_settings: Stripe.SubscriptionCreateParams["payment_settings"] =
-        subscription.payment_settings
-          ? {
-              payment_method_options: subscription.payment_settings
-                .payment_method_options
-                ? {
-                    acss_debit: subscription.payment_settings
-                      .payment_method_options.acss_debit
-                      ? {
-                          mandate_options: subscription.payment_settings
-                            .payment_method_options.acss_debit.mandate_options
-                            ? {
-                                transaction_type:
-                                  subscription.payment_settings
-                                    .payment_method_options.acss_debit
-                                    .mandate_options.transaction_type ??
-                                  undefined,
-                              }
-                            : undefined,
-                          verification_method:
-                            subscription.payment_settings.payment_method_options
-                              .acss_debit.verification_method ?? undefined,
-                        }
-                      : undefined,
-                    bancontact:
-                      subscription.payment_settings.payment_method_options
-                        .bancontact ?? undefined,
-                    card: subscription.payment_settings.payment_method_options
-                      .card
-                      ? {
-                          mandate_options: subscription.payment_settings
-                            .payment_method_options.card.mandate_options
-                            ? {
-                                amount:
-                                  subscription.payment_settings
-                                    .payment_method_options.card.mandate_options
-                                    .amount ?? undefined,
-                                amount_type:
-                                  subscription.payment_settings
-                                    .payment_method_options.card.mandate_options
-                                    .amount_type ?? undefined,
-                                description:
-                                  subscription.payment_settings
-                                    .payment_method_options.card.mandate_options
-                                    .description ?? undefined,
-                              }
-                            : undefined,
-                          network:
-                            subscription.payment_settings.payment_method_options
-                              .card.network ?? undefined,
-                          request_three_d_secure:
-                            subscription.payment_settings.payment_method_options
-                              .card.request_three_d_secure ?? undefined,
-                        }
-                      : undefined,
-                    customer_balance: subscription.payment_settings
-                      .payment_method_options.customer_balance
-                      ? {
-                          bank_transfer: subscription.payment_settings
-                            .payment_method_options.customer_balance
-                            .bank_transfer
-                            ? {
-                                eu_bank_transfer:
-                                  subscription.payment_settings
-                                    .payment_method_options.customer_balance
-                                    .bank_transfer.eu_bank_transfer ??
-                                  undefined,
-                                type:
-                                  subscription.payment_settings
-                                    .payment_method_options.customer_balance
-                                    .bank_transfer.type ?? undefined,
-                              }
-                            : undefined,
-                          funding_type:
-                            subscription.payment_settings.payment_method_options
-                              .customer_balance.funding_type ?? undefined,
-                        }
-                      : undefined,
-                    konbini:
-                      subscription.payment_settings.payment_method_options
-                        .konbini ?? undefined,
-                    us_bank_account:
-                      subscription.payment_settings.payment_method_options
-                        .us_bank_account ?? undefined,
-                  }
-                : undefined,
-              payment_method_types:
-                subscription.payment_settings.payment_method_types,
-              save_default_payment_method:
-                subscription.payment_settings.save_default_payment_method ??
-                undefined,
-            }
-          : undefined;
-
-      const transfer_data: Stripe.SubscriptionCreateParams["transfer_data"] =
-        subscription.transfer_data
-          ? {
-              destination:
-                typeof subscription.transfer_data.destination === "string"
-                  ? subscription.transfer_data.destination
-                  : subscription.transfer_data.destination?.id,
-              amount_percent:
-                subscription.transfer_data.amount_percent ?? undefined,
-            }
-          : undefined;
-
-      // Setting the trial_end to the current period end is important
-      // for maintaining the same billing period:
-      // https://support.stripe.com/questions/recreate-subscriptions-and-plans-after-moving-customer-data-to-a-new-stripe-account
-      const trial_end: Stripe.SubscriptionCreateParams["trial_end"] =
-        subscription.current_period_end;
-
-      let promotion_code: Stripe.SubscriptionCreateParams["promotion_code"] =
-        typeof subscription.discount?.promotion_code === "string"
-          ? subscription.discount?.promotion_code
-          : subscription.discount?.promotion_code?.id;
-
-      if (subscription.discount?.coupon) {
-        promotion_code = undefined;
-      }
-
-      const pending_invoice_item_interval: Stripe.SubscriptionCreateParams["pending_invoice_item_interval"] =
-        subscription.pending_invoice_item_interval;
-
-      let cancel_at: Stripe.SubscriptionCreateParams["cancel_at"] =
-        subscription.cancel_at ?? undefined;
-
-      if (subscription.cancel_at_period_end) {
-        cancel_at = undefined;
-      }
-
-      const newSubscription = await withRetry(
-        () =>
-          newStripe.subscriptions.create({
-            add_invoice_items: undefined,
-            application_fee_percent,
-            automatic_tax,
-            backdate_start_date: undefined,
-            billing_cycle_anchor: undefined,
-            billing_thresholds,
-            cancel_at_period_end: subscription.cancel_at_period_end,
-            cancel_at,
-            collection_method: subscription.collection_method,
-            coupon: subscription.discount?.coupon?.id ?? undefined,
-            currency: subscription.currency,
-            customer: customerId,
-            days_until_due: subscription.days_until_due ?? undefined,
-            default_payment_method,
-            default_source,
-            default_tax_rates,
-            description: subscription.description ?? undefined,
-            expand: undefined,
-            items,
-            metadata: subscription.metadata,
-            off_session: undefined,
-            on_behalf_of,
-            payment_behavior: undefined,
-            payment_settings,
-            pending_invoice_item_interval,
-            promotion_code,
-            proration_behavior: undefined,
-            transfer_data,
-            trial_end,
-            trial_from_plan: undefined,
-            trial_period_days: undefined,
-            trial_settings: subscription.trial_settings ?? undefined,
-          }),
-        `create subscription for ${customerId}`
-      );
-
-      subscriptionMapping[subscription.id] = newSubscription.id;
-
-      console.log(
-        chalk.green(
-          `${progress} Created subscription ${newSubscription.id} for ${newSubscription.customer}`
-        )
-      );
     } catch (error) {
       failed++;
       console.log(
@@ -616,13 +618,12 @@ export const migrateSubscriptions = async (
       );
     }
 
-    // Rate limit: wait between subscriptions
-    await sleep(DELAY_BETWEEN_SUBSCRIPTIONS_MS);
+    await sleep(delayBetweenRequestsMs);
   }
 
   console.log(
     chalk.green(
-      `\nMigration complete. Success: ${Object.keys(subscriptionMapping).length}, Failed: ${failed}`
+      `\nMigration complete. Created: ${Object.keys(subscriptionMapping).length}, Skipped: ${skipped}, Failed: ${failed}`
     )
   );
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,10 +18,12 @@ export const createStripeInstances = (
 
   const oldStripe = new Stripe(from, {
     apiVersion: "2022-11-15",
+    maxNetworkRetries: 3,
     telemetry: false,
   });
   const newStripe = new Stripe(to, {
     apiVersion: "2022-11-15",
+    maxNetworkRetries: 3,
     telemetry: false,
   });
 
@@ -41,6 +43,7 @@ export const createSingleStripeInstance = (key?: string): Stripe => {
 
   return new Stripe(key, {
     apiVersion: "2022-11-15",
+    maxNetworkRetries: 3,
     telemetry: false,
   });
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    env: {
+      STRIPE_MIGRATE_DELAY_MS: "0",
+    },
     include: ["__tests__/**/*.test.ts"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
Introduce rate-limiting and retry handling for Stripe operations. Adds DELAY_BETWEEN_SUBSCRIPTIONS_MS, MAX_RETRIES, INITIAL_RETRY_DELAY_MS, sleep and withRetry (exponential backoff on rate-limit errors) helpers and applies them to subscription/customer/list/create/cancel/paymentMethod operations.

Replaces parallel Promise.all/Promise.allSettled flows with sequential processing and short delays to avoid hitting API limits, tracks success/failure counts, and adds progress and more resilient dry-run logging and skipping for missing/deleted customers or absent payment methods. Provides final summary output after migration/cancellation.